### PR TITLE
Fix invalid method name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 /vendor
 .env
 .env.backup
+.phpunit.result.cache
 docker-compose.override.yml
 Homestead.json
 Homestead.yaml

--- a/src/ReceiverManager.php
+++ b/src/ReceiverManager.php
@@ -40,7 +40,7 @@ class ReceiverManager extends Manager implements Factory
     /**
      * Create an instance of the specified driver.
      */
-    protected function createPostmarkProvider(): PostmarkProvider
+    protected function createPostmarkDriver(): PostmarkProvider
     {
         $config = $this->config->get('services.postmark');
 

--- a/tests/ManagerTest.php
+++ b/tests/ManagerTest.php
@@ -4,6 +4,7 @@ namespace Receiver\Tests;
 
 use Receiver\Contracts\Factory;
 use Receiver\Providers\GithubProvider;
+use Receiver\Providers\PostmarkProvider;
 
 class ManagerTest extends TestCase
 {
@@ -14,5 +15,14 @@ class ManagerTest extends TestCase
         $provider = $factory->driver('github');
 
         $this->assertInstanceOf(GithubProvider::class, $provider);
+    }
+
+    public function test_it_can_instantiate_the_postmark_driver()
+    {
+        $factory = $this->app->make(Factory::class);
+
+        $provider = $factory->driver('postmark');
+
+        $this->assertInstanceOf(PostmarkProvider::class, $provider);
     }
 }


### PR DESCRIPTION
There is just a mistake in the `ReceiverManager` on the `postmark` driver. The method ends with `Provider` instead of `Driver`. This fixes it.

The test is included in the fix.
