### PR TITLE
Fixed Stripe signature header

### DIFF
--- a/src/Providers/StripeProvider.php
+++ b/src/Providers/StripeProvider.php
@@ -24,7 +24,7 @@ class StripeProvider extends AbstractProvider
     public function verify(Request $request): bool
     {
         $payload = $request->getContent();
-        $signature = $request->header('HTTP_STRIPE_SIGNATURE');
+        $signature = $request->header('STRIPE_SIGNATURE');
 
         try {
             \Stripe\Webhook::constructEvent(


### PR DESCRIPTION
The "HTTP" prefix is not required when using `Illuminate\Http\Request`. Due to this the signature header from Stripe can not be read at all and all verifications fail.

See https://www.php.net/manual/de/reserved.variables.server.php vs. https://laravel.com/docs/9.x/requests#request-headers