### PR TITLE
Fixed AbstractProvider::getClass()

### DIFF
--- a/src/Providers/AbstractProvider.php
+++ b/src/Providers/AbstractProvider.php
@@ -141,7 +141,7 @@ abstract class AbstractProvider implements ProviderContract, Responsable
      */
     protected function getClass(string $event): string
     {
-        $className = Str::studly($event);
+        $className = Str::studly(str_replace('.', ' ', $event));
         $driverName = Str::replace('Provider', '', class_basename(static::class));
 
         $basepath = rtrim($this->getHandlerNamespace(), '\\');


### PR DESCRIPTION
For events in `event.name` notation the method searched for a class `App\Http\Handlers\Provider\Event.Name`.

Fixed the method so it searches for `App\Http\Handlers\Provider\EventName`.