### PR TITLE
Change 'dispatchAfterResponse' to 'dispatch'

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,8 @@ For example, a Stripe webhook handler would be `App\Http\Handlers\Stripe\Custome
 
 Each handler is constructed with the `event` (name of the webhook event) and `data` properties.
 
+Each handler must also use the `Dispatchable` trait.
+
 ```php
 <?php
 

--- a/src/Providers/AbstractProvider.php
+++ b/src/Providers/AbstractProvider.php
@@ -165,7 +165,7 @@ abstract class AbstractProvider implements ProviderContract, Responsable
         $class = $this->getClass($event = $this->webhook->getEvent());
 
         if (class_exists($class)) {
-            $class::dispatchAfterResponse($event, $this->webhook->getData());
+            $class::dispatch($event, $this->webhook->getData());
 
             $this->dispatched = true;
         }


### PR DESCRIPTION
'dispatchAfterResponse' does not queue the handler but will instead execute it immediately (as it doesn't use Laravel's queuing system).
[dispatchAfterResposne Laravel Docs](https://laravel.com/docs/9.x/queues#dispatching-after-the-response-is-sent-to-browser:~:text=Since%20they%20are%20processed%20within%20the%20current%20HTTP%20request%2C%20jobs%20dispatched%20in%20this%20fashion%20do%20not%20require%20a%20queue%20worker%20to%20be%20running%20in%20order%20for%20them%20to%20be%20processed%3A)