### PR TITLE
Set type for generator command.

### DIFF
--- a/src/Console/Commands/GenerateReceiver.php
+++ b/src/Console/Commands/GenerateReceiver.php
@@ -24,6 +24,13 @@ class GenerateReceiver extends GeneratorCommand
     protected $description = 'Generate a custom Receiver provider.';
 
     /**
+     * The type of class being generated.
+     *
+     * @var string
+     */
+    protected $type = 'Receiver';
+
+    /**
      * @return string
      */
     protected function getStub(): string


### PR DESCRIPTION
Laravel's `\Illuminate\Console\GeneratorCommand` calls `strtolower` on `$this->type` when Artisan requests the commands arguments. If `$type` is null, then a deprecation warning is emitted. This pull request resolves that by setting `GenerateReceiver::$type` to 'Receiver'.