### PR TITLE
Add support for multiple events

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -17,7 +17,7 @@ jobs:
         php: [ 8.1, 8.2 ]
         include:
           - laravel: 9.*
-            testbench: 6.*
+            testbench: 7.*
           - laravel: 10.*
             testbench: 8.*
 

--- a/README.md
+++ b/README.md
@@ -346,7 +346,9 @@ The *`getData()`* method is used to return the payload of data that can be used 
 
 #### Receiving multiple events in a single webhook
 
-Sometimes the services will send multiple event payloads in a single webhook. In that case, you may return an array of events from the `getEvent` method and Receiver will handle them each individually.
+Sometimes the services will send multiple event payloads in a single webhook. 
+
+In this scenario you may return an array of mapped events from the `getEvent` method and Receiver will handle them each individually.
 
 For example, if the payload looks like this:
 ```json
@@ -371,10 +373,14 @@ You may return the events from the `getEvent` method like so:
 ```php
 public function getEvent(): array
 {
-    return [
-        'channel_occupied',
-        'member_added',
-    ];
+    return $events = $this->request
+            ->collect('events')
+            ->mapToGroups(
+              fn ($item) => [
+                  $item['name'] => $item
+              ]
+            )
+            ->toArray();
 }
 ```
 Receiver will then handle each event individually.

--- a/README.md
+++ b/README.md
@@ -344,6 +344,41 @@ The *`getEvent()`* method is used to return the name of the webhook event, ie. `
 
 The *`getData()`* method is used to return the payload of data that can be used within your handler. By default this is set to `$request->all()`.
 
+#### Receiving multiple events in a single webhook
+
+Sometimes the services will send multiple event payloads in a single webhook. In that case, you may return an array of events from the `getEvent` method and Receiver will handle them each individually.
+
+For example, if the payload looks like this:
+```json
+{
+    "time_ms": 1697717045179,
+    "events": [
+        {
+            "name": "channel_occupied",
+            "channel": "admin",
+            "data": {}
+        },
+        {
+            "name": "member_added",
+            "channel": "admin",
+            "data": {}
+        }
+    ]
+}
+```
+
+You may return the events from the `getEvent` method like so:
+```php
+public function getEvent(): array
+{
+    return [
+        'channel_occupied',
+        'member_added',
+    ];
+}
+```
+Receiver will then handle each event individually.
+
 ### Securing Webhooks
 
 Many webhooks have ways of verifying their authenticity as they are received, most commonly through signatures or basic authentication. No matter the strategy, Receiver allows you to write custom verification code as necessary. Simply implement the `verify` method in your provider and return true or false if it passes.

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,17 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="./vendor/phpunit/phpunit/phpunit.xsd"
-         bootstrap="vendor/autoload.php"
-         colors="true"
->
-    <coverage>
-        <include>
-            <directory suffix=".php">src</directory>
-        </include>
-    </coverage>
-    <testsuites>
-        <testsuite name="default">
-            <directory suffix="Test.php">tests</directory>
-        </testsuite>
-    </testsuites>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.4/phpunit.xsd" bootstrap="vendor/autoload.php" colors="true">
+  <coverage/>
+  <testsuites>
+    <testsuite name="default">
+      <directory suffix="Test.php">tests</directory>
+    </testsuite>
+  </testsuites>
+  <source>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+  </source>
 </phpunit>

--- a/phpunit.xml.dist.bak
+++ b/phpunit.xml.dist.bak
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="./vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+>
+    <coverage>
+        <include>
+            <directory suffix=".php">src</directory>
+        </include>
+    </coverage>
+    <testsuites>
+        <testsuite name="default">
+            <directory suffix="Test.php">tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/src/Providers/AbstractProvider.php
+++ b/src/Providers/AbstractProvider.php
@@ -6,6 +6,7 @@ use Closure;
 use Illuminate\Contracts\Support\Responsable;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Receiver\Contracts\Provider as ProviderContract;
 use Symfony\Component\HttpFoundation\Response;
@@ -35,9 +36,9 @@ abstract class AbstractProvider implements ProviderContract, Responsable
     protected Closure|null $fallback = null;
 
     /**
-     * @var bool
+     * @var array
      */
-    protected mixed $dispatched = false;
+    protected mixed $dispatchedEvents = [];
 
     /**
      * @var string
@@ -53,9 +54,9 @@ abstract class AbstractProvider implements ProviderContract, Responsable
 
     /**
      * @param Request $request
-     * @return string
+     * @return string|array
      */
-    abstract public function getEvent(Request $request): string;
+    abstract public function getEvent(Request $request): string|array;
 
     /**
      * @param Request $request
@@ -138,11 +139,14 @@ abstract class AbstractProvider implements ProviderContract, Responsable
     }
 
     /**
+     * @param string|null $key
      * @return bool
      */
-    public function dispatched(): bool
+    public function dispatched(string $key = null): bool
     {
-        return $this->dispatched;
+        return $key
+            ? in_array($key, $this->dispatchedEvents)
+            : ! empty($this->dispatchedEvents);
     }
 
     /**
@@ -162,12 +166,16 @@ abstract class AbstractProvider implements ProviderContract, Responsable
      */
     protected function handle(): static
     {
-        $class = $this->getClass($event = $this->webhook->getEvent());
+        $events = Arr::wrap($this->webhook->getEvent());
 
-        if (class_exists($class)) {
-            $class::dispatch($event, $this->webhook->getData());
+        foreach($events as $event) {
+            $class = $this->getClass($event = $this->webhook->getEvent());
 
-            $this->dispatched = true;
+            if (class_exists($class)) {
+                $class::dispatch($event, $this->webhook->getData());
+
+                $this->dispatchedEvents[] = $class;
+            }
         }
 
         return $this;

--- a/src/Providers/AbstractProvider.php
+++ b/src/Providers/AbstractProvider.php
@@ -166,13 +166,17 @@ abstract class AbstractProvider implements ProviderContract, Responsable
      */
     protected function handle(): static
     {
-        $events = Arr::wrap($this->webhook->getEvent());
+        $events = $this->webhook->getEvent();
 
-        foreach($events as $event) {
+        if(! is_array($events)) {
+            $events = [$events => $this->webhook->getData()];
+        }
+
+        foreach($events as $event => $data) {
             $class = $this->getClass($event);
 
             if (class_exists($class)) {
-                $class::dispatch($event, $this->webhook->getData());
+                $class::dispatch($event, $data);
 
                 $this->dispatchedEvents[] = $class;
             }

--- a/src/Providers/AbstractProvider.php
+++ b/src/Providers/AbstractProvider.php
@@ -169,7 +169,7 @@ abstract class AbstractProvider implements ProviderContract, Responsable
         $events = Arr::wrap($this->webhook->getEvent());
 
         foreach($events as $event) {
-            $class = $this->getClass($event = $this->webhook->getEvent());
+            $class = $this->getClass($event);
 
             if (class_exists($class)) {
                 $class::dispatch($event, $this->webhook->getData());


### PR DESCRIPTION
This PR adds support for handling multiple events in a single payload.

The `getEvent` method has been updated to support the return of either a `string` or `array` value, and the `handle` method updated accordingly.

Resolves https://github.com/hotmeteor/receiver/issues/13