### PR TITLE
Fix: Event format with the Github provider

### DIFF
--- a/src/Providers/GithubProvider.php
+++ b/src/Providers/GithubProvider.php
@@ -26,6 +26,9 @@ class GithubProvider extends AbstractProvider
      */
     public function getEvent(Request $request): string
     {
-        return implode('_', [$request->header('X-GitHub-Event'), $request->input('action')]);
+	return implode('_', array_filter([
+            $request->header('X-GitHub-Event'),
+            $request->input('action')
+        ]));
     }
 }


### PR DESCRIPTION
This PR will fix artefact event name to the Github provider.

When the event triggered without action the provider add _ character end of line. 

It may be on the event : push, installation, fork etc...